### PR TITLE
2021-05 shisama

### DIFF
--- a/posts/2021/05.md
+++ b/posts/2021/05.md
@@ -28,3 +28,9 @@ guest:
   - name: "holly"
     link: https://twitter.com/1013Youmeee
 ---
+
+### [Learn CSS](https://web.dev/learn/css/)
+
+- 共有者: shisama
+
+---

--- a/posts/2021/05.md
+++ b/posts/2021/05.md
@@ -48,6 +48,8 @@ guest:
 - Tridentには影響しない
   - 詳細は不明ですが、IEモードはまだまだ続くし、Tridentにはセキュリティパッチとかあたっていくのかも(?)
 
+> 最新の Web サイトやアプリを開発している Web 開発者の方は、この日を待ち望んでいたことと思います。Internet Explorer と最新ブラウザーを同時にサポートし続けることは困難です。
+
 WordpressもIEサポート終了アナウンス出してました。
 [News – Dropping support for Internet Explorer 11 – WordPress.org](https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/)
 

--- a/posts/2021/05.md
+++ b/posts/2021/05.md
@@ -29,8 +29,28 @@ guest:
     link: https://twitter.com/1013Youmeee
 ---
 
-### [Learn CSS](https://web.dev/learn/css/)
+### [Internet Explorer は Microsoft Edge へ – Windows 10 の Internet Explorer 11 デスクトップアプリは 2022 年 6 月 15 日にサポート終了 - Windows Blog for Japan](https://blogs.windows.com/japan/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge/)
 
 - 共有者: shisama
+
+2022/6/15(日本時間2022/6/16)にMicrosoftはIEのサポートを終了します！
+お疲れさまでした！
+
+- EdgeのIEモードは2029年までつづきます
+
+> 注: このサポート終了は、提供中の Windows 10 LTSC やWindows Server 上の Internet Explorer 11 デスクトップ アプリケーションには影響しません。また、MSHTML (Trident) エンジンにも影響はございません。
+
+- Windows 10 LTSC(Long Term Support Channel)やWindows ServerのIEには影響しない
+  - Enterprise LTSCは2021年下半期にリリースされて、5年サポートとのこと
+  - [Windows 10 長期サービス チャネル (LTSC) 次期リリースについて - Windows Blog for Japan](https://blogs.windows.com/japan/2021/02/25/the-next-windows-10-long-term-servicing-channel-ltsc-release/)
+  - 過去に出たLTSCは10年サポート
+    - [Lifecycle FAQ - Internet Explorer and Microsoft Edge | Microsoft Docs](https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge)を見ても過去リリースされたLTSCのIEについては触れられていない
+- Tridentには影響しない
+  - 詳細は不明ですが、IEモードはまだまだ続くし、Tridentにはセキュリティパッチとかあたっていくのかも(?)
+
+WordpressもIEサポート終了アナウンス出してました。
+[News – Dropping support for Internet Explorer 11 – WordPress.org](https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/)
+
+IE11サポート終了については「[IE11 サポート終了の歴史 | blog.jxck.io](https://blog.jxck.io/entries/2021-05-11/end-of-ie.html)」を。
 
 ---

--- a/posts/2021/05.md
+++ b/posts/2021/05.md
@@ -36,23 +36,36 @@ guest:
 2022/6/15(日本時間2022/6/16)にMicrosoftはIEのサポートを終了します！
 お疲れさまでした！
 
-> Microsoft Edge の Internet Explorer モードは、少なくとも 2029 年まではサポートする予定です。
-
-> 注: このサポート終了は、提供中の Windows 10 LTSC やWindows Server 上の Internet Explorer 11 デスクトップ アプリケーションには影響しません。また、MSHTML (Trident) エンジンにも影響はございません。
+- EdgeのIEモードは、少なくとも 2029 年まではサポートする予定です。
 
 - Windows 10 LTSC(Long Term Support Channel)やWindows ServerのIEには影響しない
   - Enterprise LTSCは2021年下半期にリリースされて、5年サポートとのこと
   - [Windows 10 長期サービス チャネル (LTSC) 次期リリースについて - Windows Blog for Japan](https://blogs.windows.com/japan/2021/02/25/the-next-windows-10-long-term-servicing-channel-ltsc-release/)
   - 過去に出たLTSCは10年サポート
-    - [Lifecycle FAQ - Internet Explorer and Microsoft Edge | Microsoft Docs](https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge)を見ても過去リリースされたLTSCのIEについては触れられていない
+    - [Lifecycle FAQ - Internet Explorer and Microsoft Edge | Microsoft Docs](https://docs.microsoft.com/en-us/lifecycle/faq/internet-explorer-microsoft-edge)
+    - 2019年に出たLTSCは2029年までサポート...??
 - Tridentには影響しない
-  - 詳細は不明ですが、IEモードはまだまだ続くし、Tridentにはセキュリティパッチとかあたっていくのかも(?)
+  - 詳細は不明ですが、IEモードはまだまだ続くし、Tridentにはパッチがあたっていくのかも(?)
+- 「[毎秒約 579 件のパスワード攻撃 (英語)](https://www.microsoft.com/security/blog/2021/05/12/securing-a-new-world-of-hybrid-work-what-to-know-and-what-to-do/) が仕掛けられており、この課題に対応できるブラウザーが必要とされています。」
+  - 1日5000万件のPassword atack、ブロックした脅威のあるメール300億件...
+- 「企業が保有するレガシ アプリの数は平均で 1,678 個と言われています」
+- 「最新の Web サイトやアプリを開発している Web 開発者の方は、この日を待ち望んでいたことと思います。」
 
-> 最新の Web サイトやアプリを開発している Web 開発者の方は、この日を待ち望んでいたことと思います。Internet Explorer と最新ブラウザーを同時にサポートし続けることは困難です。
+#### 関連記事
+- FAQのページがよくまとまっています。
+  - [「Internet Explorer 11 デスクトップ アプリケーションのサポート終了」の発表に関連する FAQ - Windows Blog for Japan](https://blogs.windows.com/japan/2021/05/19/internet-explorer-11-desktop-app-retirement-faq/)
 
-WordpressもIEサポート終了アナウンス出してました。
-[News – Dropping support for Internet Explorer 11 – WordPress.org](https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/)
+- 日本マイクロソフトのIE/Edgeサポートチームから移行ガイドラインも出ています
+  - [Internet Explorer から Microsoft Edge への移行ガイドライン | Japan Developer Support Internet Team Blog](https://jpdsi.github.io/blog/internet-explorer-microsoft-edge/guidelines-for-migrating-from-ie-to-microsoft-edge/)
+    - IE -> Edgeには4段階ある
+      - ステージ 1. IE を既定のブラウザーとして運用している
+      - ステージ 2. Edge には移行しているが、IE モードと IEデスクトップ アプリ (スタンドアロンの IE11) を併用している
+      - ステージ 3. IE モードを部分的に利用しているが IE デスクトップ アプリはもう使っていない
+      - ステージ 4. Edge に完全に移行できており、IE モード含めて完全に必要ない
 
-IE11サポート終了については「[IE11 サポート終了の歴史 | blog.jxck.io](https://blog.jxck.io/entries/2021-05-11/end-of-ie.html)」を。
+- WordPressもIEサポート終了アナウンス出してましたね
+  - [News – Dropping support for Internet Explorer 11 – WordPress.org](https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/)
+
+- IE11サポート終了の歴史については「[IE11 サポート終了の歴史 | blog.jxck.io](https://blog.jxck.io/entries/2021-05-11/end-of-ie.html)」を。
 
 ---

--- a/posts/2021/05.md
+++ b/posts/2021/05.md
@@ -36,7 +36,7 @@ guest:
 2022/6/15(日本時間2022/6/16)にMicrosoftはIEのサポートを終了します！
 お疲れさまでした！
 
-- EdgeのIEモードは2029年までつづきます
+> Microsoft Edge の Internet Explorer モードは、少なくとも 2029 年まではサポートする予定です。
 
 > 注: このサポート終了は、提供中の Windows 10 LTSC やWindows Server 上の Internet Explorer 11 デスクトップ アプリケーションには影響しません。また、MSHTML (Trident) エンジンにも影響はございません。
 


### PR DESCRIPTION
Big News
[Internet Explorer は Microsoft Edge へ – Windows 10 の Internet Explorer 11 デスクトップアプリは 2022 年 6 月 15 日にサポート終了 - Windows Blog for Japan](https://blogs.windows.com/japan/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge/)

<del>
どっちかにする予定。
マンスリーまでにCSSのやつやって感想を言うようにするかも。マンスリー駆動Learn。
見た目のすごさで後者にするかも

- https://web.dev/learn/css/
- https://github.com/Renovamen/playground-macos
</del>