### PR TITLE
Topic/a11y

### DIFF
--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -11,15 +11,15 @@ const { topics } = Astro.props
 <section class="timeline">
   {
     topics.map(topic => (
-      <>
+      <section>
         <div class="month-row">
-          <div class="month-dot">{topic.month}月</div>
+          <h2 class="month-dot">{topic.month}月</h2>
         </div>
         <div class="row">
           <div class="notable">
             {topic.notableTopics.map(topic => (
-              <div class="notable-row">
-                <div class="notable-header">
+              <section class="notable-row">
+                <h3 class="notable-header">
                   {topic.url ? (
                     <a
                       class="notable-title-link"
@@ -32,14 +32,14 @@ const { topics } = Astro.props
                   ) : (
                     <span class="notable-title">{topic.title}</span>
                   )}
-                </div>
+                </h3>
                 <div>{topic.overview}</div>
-              </div>
+              </section>
             ))}
           </div>
-          <div class="topic">
+          <ul class="topic">
             {topic.topics.map(topic => (
-              <div class="topic-row">
+              <li class="topic-row">
                 <div class="dot" />
                 <a
                   class="topic-link"
@@ -50,11 +50,11 @@ const { topics } = Astro.props
                   {topic.title}
                 </a>
                 <span class="topic-date">{topic.date}</span>
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
-      </>
+      </section>
     ))
   }
 </section>
@@ -96,20 +96,22 @@ const { topics } = Astro.props
     place-items: center;
     top: 50%;
     left: 50%;
-    width: 42px;
-    height: 42px;
+    width: 48px;
+    height: 48px;
     border-radius: 50%;
     background-color: var(--color-primary-0);
     border: 4px solid var(--color-surface-mixed-100);
     transform: translate(-50%, -50%);
+    font-size: 15px;
+    font-weight: normal;
+    margin: 0;
   }
-
   .row {
     position: relative;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-gap: 1rem;
-    padding: 1rem 0;
+    padding: 2rem 0 1rem;
     margin-bottom: 1rem;
     box-sizing: border-box;
   }
@@ -143,6 +145,9 @@ const { topics } = Astro.props
     }
   }
 
+  .notable-header {
+    margin: 0;
+  }
   .notable-title {
     font-weight: bold;
     font-size: 1.2rem;
@@ -152,6 +157,9 @@ const { topics } = Astro.props
     display: flex;
     flex-direction: column;
     gap: 40px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
   .topic-row {
     position: relative;

--- a/src/components/Timeline.astro
+++ b/src/components/Timeline.astro
@@ -40,7 +40,6 @@ const { topics } = Astro.props
           <ul class="topic">
             {topic.topics.map(topic => (
               <li class="topic-row">
-                <div class="dot" />
                 <a
                   class="topic-link"
                   href={topic.url}
@@ -48,8 +47,8 @@ const { topics } = Astro.props
                   rel="noopener noreferrer"
                 >
                   {topic.title}
+                  <span class="topic-date">{topic.date}</span>
                 </a>
-                <span class="topic-date">{topic.date}</span>
               </li>
             ))}
           </ul>
@@ -166,22 +165,24 @@ const { topics } = Astro.props
     display: flex;
     gap: 10px;
     padding-left: 14px;
-  }
-  .dot {
-    position: absolute;
-    top: 2px;
-    left: -20px;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background-color: var(--color-surface-mixed-400);
-    border: 4px solid var(--color-surface-mixed-100);
+    &:after {
+      content: "";
+      display: block;
+      position: absolute;
+      top: 2px;
+      left: -20px;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background-color: var(--color-surface-mixed-400);
+      border: 4px solid var(--color-surface-mixed-100);
+    }
   }
   .topic-link {
     text-decoration: none;
     color: var(--color-primary-300);
     font-size: 1.2rem;
-
+    line-height: 1.5;
     &:hover {
       text-decoration: underline;
     }
@@ -195,5 +196,8 @@ const { topics } = Astro.props
     padding-top: 4px;
     min-width: 94px;
     color: var(--color-surface-mixed-600);
+    font-size: 1rem;
+    margin-left: 12px;
+    white-space: nowrap;
   }
 </style>


### PR DESCRIPTION
- HTMLを構造化
- dotを疑似要素に
- `n月` に余白を追加

変更後

<img width="1259" alt="image" src="https://github.com/cybozu/frontend-monthly/assets/1995370/5ffa233d-ebe2-41c1-bedd-7e258a73249d">

変更前

<img width="1259" alt="image" src="https://github.com/cybozu/frontend-monthly/assets/1995370/8fa27e0e-2ec2-4189-8510-515b38702fb5">
